### PR TITLE
Disconnect request connection for each request

### DIFF
--- a/components/Server.coffee
+++ b/components/Server.coffee
@@ -75,5 +75,7 @@ for each HTTP request it receives"
       res: res
     @outPorts.request.endGroup()
     @outPorts.request.endGroup()
+    # End of request
+    @outPorts.request.disconnect()
 
 exports.getComponent = -> new Server


### PR DESCRIPTION
Disconnection of `REQUEST` port should take place for every request. It otherwise breaks the protocol of applying middleware on disconnections. See `noflo-webserver/BasicAuth`, `noflo-webserver/BodyParser`, `noflo-webserver/Profiler`, etc
